### PR TITLE
Implement Staff Registration

### DIFF
--- a/src/main/kotlin/controllers/ManagementAuthController.kt
+++ b/src/main/kotlin/controllers/ManagementAuthController.kt
@@ -9,7 +9,6 @@ import org.mindrot.jbcrypt.BCrypt
 
 object ManagementAuthController {
 
-    // Returns a Pair<Int, UserRole>? so the route knows if they are a Manager or Worker
     fun verifyStaffLogin(staffIdInput: String, rawPasswordInput: String): Pair<Int, UserRole>? {
         return transaction {
             // find user by staffId
@@ -25,6 +24,56 @@ object ManagementAuthController {
             } else {
                 return@transaction null
             }
+        }
+    }
+
+    fun createStaffAccount(
+        firstName: String,
+        lastName: String,
+        dobString: String,
+        email: String,
+        phone: String?,
+        rawPassword: String,
+        roleString: String
+    ): String {
+        return transaction {
+            // Check if email exists
+            val existing = Users.selectAll().where { Users.email eq email }.firstOrNull()
+            if (existing != null) return@transaction "email_exists"
+
+            // Password Strength Check
+            val passRegex = "^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#\$%^&*]).{8,}\$".toRegex()
+            if (!passRegex.matches(rawPassword)) return@transaction "weak_password"
+
+            // Parse Data (DOB and Role)
+            val parsedDob = java.time.LocalDate.parse(dobString)
+            val roleEnum = try { UserRole.valueOf(roleString) } catch (e: Exception) { UserRole.WORKER }
+
+            // Generate a unique 8-digit Staff ID
+            var generatedStaffId: String
+            var isUnique = false
+            do {
+                generatedStaffId = (10000000..99999999).random().toString()
+                val idCheck = Users.selectAll().where { Users.staffId eq generatedStaffId }.firstOrNull()
+                if (idCheck == null) isUnique = true
+            } while (!isUnique)
+
+            // Hash Password & Insert User Info
+            val hashedPassword = BCrypt.hashpw(rawPassword, BCrypt.gensalt())
+
+            Users.insert {
+                it[Users.staffId] = generatedStaffId
+                it[Users.firstName] = firstName
+                it[Users.lastName] = lastName
+                it[Users.email] = email
+                it[Users.phoneNumber] = phone
+                it[Users.password] = hashedPassword
+                it[Users.role] = roleEnum
+                it[Users.dob] = parsedDob
+            }
+
+            // Return the generated ID so the route can show it to the Manager
+            return@transaction generatedStaffId
         }
     }
 }

--- a/src/main/kotlin/routes/managementRoutes.kt
+++ b/src/main/kotlin/routes/managementRoutes.kt
@@ -77,6 +77,39 @@ fun Route.managementRoutes() {
                         call.respondText("Login page not found", status = HttpStatusCode.NotFound)
                     }
                 }
+                post {
+                    // Get parameters from frontend
+                    val formParameters = call.receiveParameters()
+
+                    val firstName = formParameters["firstname"]
+                    val lastName = formParameters["surname"]
+                    val dob = formParameters["date_of_birth"]
+                    val email = formParameters["email"]
+                    val phone = formParameters["phoneNumber"]
+                    val role = formParameters["role"]
+                    val password = formParameters["password"]
+
+                    // Basic null check
+                    if (firstName.isNullOrBlank() || lastName.isNullOrBlank() || dob.isNullOrBlank() ||
+                        email.isNullOrBlank() || role.isNullOrBlank() || password.isNullOrBlank()
+                    ) {
+                        call.respondRedirect("/management/staff/create?error=missing_fields")
+                        return@post
+                    }
+
+                    // Send to account creation function
+                    val result = ManagementAuthController.createStaffAccount(
+                        firstName, lastName, dob, email, phone, password, role
+                    )
+
+                    // Handle the response
+                    if (result == "email_exists" || result == "weak_password") {
+                        call.respondRedirect("/management/staff/create?error=$result")
+                    } else {
+                        // Return the staff ID to the manager as confirmation
+                        call.respondRedirect("/management/staff/create?success=$result")
+                    }
+                }
             }
 
             route("/login") {

--- a/src/main/resources/static/views/management/create.html
+++ b/src/main/resources/static/views/management/create.html
@@ -20,9 +20,9 @@
     <h1>Create Staff Account</h1>
 </header>
 <main>
-    <form action="/customers/register" method="post" id="register-form" novalidate>
+    <form action="/management/staff/create" method="post" id="register-form" novalidate>
 
-        <div id="reg-err-banner" class="err-banner" role="alert">
+        <div id="reg-err-banner" class="err-banner" role="alert" style="display: none;">
             An account with this email already exists.
         </div>
 
@@ -145,6 +145,30 @@
 </main>
 
 <script>
+    // Checks for errors on page load
+    window.onload = function() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const banner = document.getElementById('reg-err-banner');
+
+        if (urlParams.get('error') === 'weak_password') {
+            banner.innerText = "Password must contain a number, uppercase, lowercase, and special character.";
+            banner.style.display = 'block';
+        }
+
+        else if (urlParams.get('error') === 'email_exists') {
+            banner.innerText = "A user with this email already exists.";
+            banner.style.display = 'block';
+        }
+
+        // Success - Show the manager the new staff ID for the newly created account
+        else if (urlParams.get('success')) {
+            banner.innerText = "Account created successfully! The new Staff ID is: " + urlParams.get('success');
+            banner.style.backgroundColor = "#d4edda";
+            banner.style.color = "#155724";
+            banner.style.display = 'block';
+        }
+    };
+
     // Toggle password
     const passInput = document.getElementById('password');
     const showBtn = document.getElementById('show-pass');
@@ -217,7 +241,7 @@
             e.preventDefault();
             console.log("Validation failed");
         } else {
-            console.log("Form looks good, submitting...");
+            form.submit();
         }
     });
 </script>


### PR DESCRIPTION
 Backend
* Added createStaffAccount which takes in user information, verifies that the email is unique and the password is strong enough, and then creates the account on the database, returning the new staff id.
* Added POST /management/staff/create endpoint to take in form parameters from the frontend and pass them into createStaffAccount. Passes the result of createStaffAccount back to the frontend to display.

Frontend
* Added error banners for email already exists and password being too weak via a Window.onload script
* Added a green success banner displaying the new staffId if the account creation was successful.