### PR TITLE
Added analyst role to worker account creation & login

### DIFF
--- a/src/main/kotlin/database/DatabaseSeeder.kt
+++ b/src/main/kotlin/database/DatabaseSeeder.kt
@@ -209,7 +209,7 @@ fun insertUsers(numUsers: Int, role: UserRole) {
         val dobString = faker.timeAndDate().birthday(18, 99, "yyyy-MM-dd")
         this[Users.dob] = LocalDate.parse(dobString, DateTimeFormatter.ISO_LOCAL_DATE)
 
-        if (role == UserRole.WORKER || UserRole.MANAGER == role || UserRole.DRIVER == role) {
+        if (role == UserRole.WORKER || role == UserRole.MANAGER || role == UserRole.DRIVER || role == UserRole.ANALYST) {
             this[Users.staffId] = generateUniqueStaffId()
         }
     }

--- a/src/main/resources/static/views/management/create.html
+++ b/src/main/resources/static/views/management/create.html
@@ -116,6 +116,7 @@
                     <option value="WORKER">Worker</option>
                     <option value="MANAGER">Manager</option>
                     <option value="DRIVER">Driver</option>
+                    <option value="ANALYST">Analyst</option>
                 </select>
                 <span class="field-err" id="role-err" role="alert">Please select a role.</span>
             </div>


### PR DESCRIPTION
1.  **`src/main/kotlin/database/DatabaseSeeder.kt`**:
    *   **Ensured Staff ID Assignment for Analysts**: Modified the `insertUsers` function to include the `ANALYST` role in the condition for assigning `staffId`. This resolves an issue where seeded analyst accounts would not have a `staffId`, preventing them from logging in. Now, all seeded analysts will correctly receive a unique `staffId`.

2.  **`src/main/resources/static/views/management/create.html`**:
    *   **Added 'Analyst' Option to Staff Creation Form**: Updated the manager's staff account creation form (`<select id="role" ...>`) to include 'Analyst' as a selectable role. This allows managers to create new analyst accounts through the web interface.