### PR TITLE
Added management routes back into Routing.kt

### DIFF
--- a/src/main/kotlin/Routing.kt
+++ b/src/main/kotlin/Routing.kt
@@ -41,9 +41,11 @@ fun Application.configureRouting() {
         orderRoutes()
         stockRoutes()
         warehouseRoutes()
+        managementRoutes()
 
         userRoutes()
         testingRoutes()
+
         
         static("/static") {
             resources("static")


### PR DESCRIPTION
Fixed an issue where management routes weren't accessible due to the function containing them not being included in Routing.kt