### PR TITLE
Seeded Crates & assigned individual barcodes

### DIFF
--- a/src/main/kotlin/database/DatabaseSeeder.kt
+++ b/src/main/kotlin/database/DatabaseSeeder.kt
@@ -449,8 +449,8 @@ fun seedRandomOrderItem(orderId: Int, subsAllowed: Boolean = true): Float {
 
     // find if product is sold by weight & then generate either quantity or weight
     val soldByWeight = product[Product.soldByWeight]
-    val quantity = if (soldByWeight) null else (1..10).random()
-    val weight = if (soldByWeight) 0.1f + (4.9f * nextFloat()) else null
+    val quantity = if (soldByWeight) null else listOf(1, 1, 1, 1, 1, 1, 2, 2, 3, 4, 5).random() // Random quantity weighted towards just one item
+    val weight = if (soldByWeight) 0.1f + (1.5f * nextFloat()) else null // Random weight is up to 1.6kg
 
     // 20% chance of substituting the item
     val randomNum = (1..10).random()

--- a/src/main/kotlin/database/DatabaseSeeder.kt
+++ b/src/main/kotlin/database/DatabaseSeeder.kt
@@ -30,6 +30,7 @@ fun seedDatabase() {
     seedNewOrders()
     seedWastageLogs()
     seedOffsaleLogs()
+    seedCrates()
 }
 
 fun refreshDatabase() {
@@ -589,4 +590,19 @@ fun generateUniqueStaffId(): String {
 
     assignedStaffIds.add(newId)
     return newId
+}
+
+fun seedCrates() {
+    transaction {
+        for (i in 1..400) {
+            // Generate barcodes for each crate
+            val crateBarcode = "CRATE-${i.toString().padStart(3, '0')}"
+
+            Crate.insert {
+                it[Crate.barcode] = crateBarcode
+                it[Crate.orderId] = null
+                it[Crate.routeId] = null
+            }
+        }
+    }
 }

--- a/src/main/kotlin/database/Tables.kt
+++ b/src/main/kotlin/database/Tables.kt
@@ -191,6 +191,7 @@ object SubstituteItem : Table("substitute") {
 
 object Crate : Table("crate") {
     val id = integer("id").autoIncrement()
+    val barcode = varchar("barcode", 50)
     val orderId = reference("order_id", Order.id).nullable()
     val routeId = reference("route_id", DeliveryRoute.id).nullable()
 


### PR DESCRIPTION
**Crate Seeding**
- Added the `barcode` attribute to the `Crate` table
- Setup the seeding function for 400 crates
- Each crate has the barcode "Crate-{crateId}"

**Order Item Quantity Seeding**
- Changed the quantity of each orderItem that gets seeded to more accurately reflect a normal shop.
- The Quantity is more weighted towards a single item, but up to 5 of each item can be added.
