### PR TITLE
Scan crate false error message

### DIFF
--- a/src/main/kotlin/controllers/PicklistController.kt
+++ b/src/main/kotlin/controllers/PicklistController.kt
@@ -172,9 +172,16 @@ object PicklistController {
                 it[pickerId] = workerId
             }
 
-            // calculate the number of crates needed
-            val totalItems = Picklist.selectAll().where { Picklist.id eq availableListId }.single()[Picklist.quantity]
-            val cratesNeeded = ceil(totalItems.toDouble() / MAX_ITEMS_PER_CRATE).toInt()
+            // calculate the number of crates needed based on distinct orders
+            val pickItems = PickItem.selectAll().where { PickItem.picklistId eq availableListId }.toList()
+            val itemsByOrder = pickItems.groupBy { it[PickItem.orderId] }
+
+            var cratesNeeded = 0
+            for ((_, items) in itemsByOrder) {
+                var itemCount = 0
+                for (item in items) { itemCount += item[PickItem.quantity] ?: 1 }
+                cratesNeeded += ceil(itemCount.toDouble() / MAX_ITEMS_PER_CRATE).toInt()
+            }
 
             // picklist ID along with the num of crates needed
             Pair(availableListId, cratesNeeded)
@@ -203,8 +210,15 @@ object PicklistController {
         return transaction {
             // Validate crates exist and aren't in use
             val cratesToAssign = Crate.selectAll().where { Crate.barcode inList scannedBarcodes }.toList()
-            if (cratesToAssign.size != scannedBarcodes.size) return@transaction "One or more scanned crates do not exist."
-            if (cratesToAssign.any { it[Crate.orderId] != null }) return@transaction "Crate already in use!"
+
+            if (cratesToAssign.size != scannedBarcodes.size) {
+                rollback() // Undo any changes
+                return@transaction "One or more scanned crates do not exist."
+            }
+            if (cratesToAssign.any { it[Crate.orderId] != null }) {
+                rollback()
+                return@transaction "Crate already in use!"
+            }
 
             // Order the items on the pick list by their order id
             val pickItems = PickItem.selectAll().where { PickItem.picklistId eq picklistId }.toList()

--- a/src/main/resources/static/views/warehouse/scanCrate.html
+++ b/src/main/resources/static/views/warehouse/scanCrate.html
@@ -76,7 +76,7 @@
 <div class="modal-backdrop"></div>
 <div class="err-popup-modal">
     <div class="modal-content">
-        <h2 class="modal-title">Crate Already In Use</h2>
+        <h2 class="modal-title">Scanning error</h2>
         <p class="modal-text">One or more of the crate IDs you entered is currently assigned to another order. Please
             check the crate ID and try again.</p>
         <button class="btn-primary close-modal-btn">OK</button>


### PR DESCRIPTION
- Fixed an error where the user would get an error despite entering the correct number of crates.
- Fixed an issue where crates would still be assigned to an order on the database despite an error ocurring when clicking done on the scan crates screen.